### PR TITLE
Windows ACL api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ libc = "0.2"
 thiserror = {version = "1.0", optional = true}
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["securitybaseapi", "accctrl", "aclapi", "winerror", "handleapi"] }
+windows = { version = "0.39", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_Security_Authorization"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,7 @@ impl AllocErr for StdSystemError {
 }
 
 // Prefered error type in (internals) tests.
+#[cfg(test)]
 cfg_if::cfg_if!(
     if #[cfg(feature = "std")] {
         pub(crate) use StdSystemError as TestSysErr;

--- a/src/harden.rs
+++ b/src/harden.rs
@@ -127,7 +127,9 @@ fn disable_core_dumps<E: SysErr>() -> Result<(), HardenError<E>> {
 /// process.
 #[cfg(windows)]
 fn windows_set_dacl<E: SysErr + AllocErr>() -> Result<(), HardenError<E>> {
-    use winapi::um::winnt::{PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, SYNCHRONIZE};
+    use windows::Win32::System::Threading::{
+        PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+    };
 
     use crate::win_acl::TokenUser;
 
@@ -137,7 +139,7 @@ fn windows_set_dacl<E: SysErr + AllocErr>() -> Result<(), HardenError<E>> {
 
     // Now specify the ACL we want to create
     let acl_spec = crate::win_acl::EmptyAcl;
-    let access_mask = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE;
+    let access_mask = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | PROCESS_SYNCHRONIZE;
     let acl_spec = crate::win_acl::AddAllowAceAcl::new(acl_spec, access_mask, sid);
 
     // Create ACL and set as process DACL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@
 //!
 //! #[cfg(windows)]
 //! fn harden_process() -> Result<(), secmem_proc::error::EmptySystemError> {
-//!     use winapi::um::winnt::{
-//!         PROCESS_CREATE_THREAD, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
-//!         SYNCHRONIZE,
+//!     use windows::Win32::System::Threading::{
+//!         PROCESS_CREATE_THREAD, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+//!         PROCESS_TERMINATE,
 //!     };
 //!
 //!     use secmem_proc::win_acl::{AddAllowAceAcl, EmptyAcl, TokenUser};
@@ -76,7 +76,7 @@
 //!     let acl_spec = EmptyAcl;
 //!     let access_mask = PROCESS_QUERY_LIMITED_INFORMATION
 //!         | PROCESS_TERMINATE
-//!         | SYNCHRONIZE
+//!         | PROCESS_SYNCHRONIZE
 //!         | PROCESS_CREATE_THREAD;
 //!     let acl_spec = AddAllowAceAcl::new(acl_spec, access_mask, sid);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![warn(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #![warn(clippy::must_use_candidate)]
+#![allow(clippy::needless_lifetimes)]
 //! `secmem-proc` is a crate designed to harden a process against
 //! *low-privileged* attackers running on the same system trying to obtain
 //! secret memory contents of the current process. More specifically, the crate
@@ -66,6 +67,8 @@ pub mod error;
 pub mod harden;
 #[cfg(all(feature = "rlimit", unix))]
 pub mod rlimit;
+#[cfg(windows)]
+pub mod win_acl;
 
 pub use harden::harden_process;
 #[cfg(feature = "std")]

--- a/src/win_acl.rs
+++ b/src/win_acl.rs
@@ -1,0 +1,177 @@
+//! Safer Windows DACL API.
+
+use crate::error::{AllocErr, SysErr};
+use crate::internals::win32 as internals;
+use winapi::shared::minwindef::DWORD as Dword;
+
+pub use internals::SidRef;
+
+/// Completed (initialized) ACL.
+pub struct Acl(internals::AclBox);
+
+impl Acl {
+    /// Set the ACL `self` as protected DACL for the current process.
+    pub fn set_process_dacl_protected<E: SysErr>(&self) -> Result<(), E> {
+        use winapi::um::accctrl::SE_KERNEL_OBJECT;
+
+        // SAFETY: `get_process_handle()` gives a valid handle to an `SE_KERNEL_OBJECT`
+        // type object
+        unsafe {
+            self.0
+                .set_protected(internals::get_process_handle(), SE_KERNEL_OBJECT)
+        }
+    }
+}
+
+/// User associated with an access token.
+pub struct TokenUser(internals::TokenUserBox);
+
+impl TokenUser {
+    /// Get a reference to the user SID.
+    #[must_use]
+    pub fn sid<'a>(&'a self) -> SidRef<'a> {
+        self.0.sid()
+    }
+
+    /// Create [`TokenUser`] for the user of the current process.
+    pub fn process_user<E: SysErr + AllocErr>() -> Result<Self, E> {
+        use winapi::um::winnt::TOKEN_QUERY;
+        // SAFETY: `get_process_handle()` gives a valid process handle
+        let process_tok = unsafe {
+            internals::AccessToken::open_process_token(internals::get_process_handle(), TOKEN_QUERY)
+        }?;
+        let user = process_tok.get_token_user()?;
+        Ok(Self(user))
+    }
+}
+
+/// Module with some complicated machinery to enable safe construction of ACLs
+/// with guarantied correct allocation size without using an intermediate
+/// [`Vec`] (which would require std).
+mod acl_construction {
+    use super::*;
+
+    // not exported out of module (so module private)
+    /// Owned ACL during initialisation (i.e. when some ACEs haven't yet been
+    /// added, while space for them was allocated during creation).
+    pub struct AclPartial(internals::AclBox);
+    impl AclPartial {
+        /// Turn into a finished ACL.
+        ///
+        /// This is safe since any [`AclPartial`] is initialised as an ACL and
+        /// thus can safely used as such. However, calling this method when the
+        /// ACL hasn't been (fully) filled with ACEs is a logic error. No ACEs
+        /// can be added afterwards.
+        fn declare_final(self) -> Acl {
+            Acl(self.0)
+        }
+    }
+
+    // not exported out of module (so module private)
+    /// Helper trait for constructing an ACL with a properly sized allocation
+    /// safely.
+    pub trait AclConstruction {
+        /// Construct an ACL according to the specification `self`, giving the
+        /// caller the ability to modify the allocation size through the
+        /// callback `f`.
+        fn realize_with_size<E: SysErr + AllocErr, F: FnOnce(&mut internals::AclSize)>(
+            self,
+            f: F,
+        ) -> Result<AclPartial, E>;
+    }
+
+    /// Constructor for an empty ACL.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+    pub struct EmptyAcl;
+
+    impl EmptyAcl {
+        #[must_use]
+        pub fn new() -> Self {
+            EmptyAcl
+        }
+
+        pub fn create<E: SysErr + AllocErr>(self) -> Result<Acl, E> {
+            let acl = self.realize_with_size(|_s| {})?;
+            Ok(acl.declare_final())
+        }
+    }
+
+    impl AclConstruction for EmptyAcl {
+        fn realize_with_size<E: SysErr + AllocErr, F: FnOnce(&mut internals::AclSize)>(
+            self,
+            f: F,
+        ) -> Result<AclPartial, E> {
+            let mut size = internals::AclSize::new();
+            f(&mut size);
+            let acl = size.allocate()?;
+            Ok(AclPartial(acl))
+        }
+    }
+
+    /// Constructor for an ACL `constructor` with an additional allowed ACE.
+    pub struct AddAllowAceAcl<'a, C: AclConstruction> {
+        constructor: C,
+        access_mask: Dword,
+        sid: SidRef<'a>,
+    }
+
+    impl<'a, C: AclConstruction> AddAllowAceAcl<'a, C> {
+        pub fn new(constructor: C, access_mask: Dword, sid: SidRef<'a>) -> Self {
+            AddAllowAceAcl {
+                constructor,
+                access_mask,
+                sid,
+            }
+        }
+
+        pub fn create<E: SysErr + AllocErr>(self) -> Result<Acl, E> {
+            let acl = self.realize_with_size(|_s| {})?;
+            Ok(acl.declare_final())
+        }
+    }
+
+    impl<'a, C: AclConstruction> AclConstruction for AddAllowAceAcl<'a, C> {
+        fn realize_with_size<E: SysErr + AllocErr, F: FnOnce(&mut internals::AclSize)>(
+            self,
+            f: F,
+        ) -> Result<AclPartial, E> {
+            let mut acl = self.constructor.realize_with_size(|size| {
+                size.add_allowed_ace(self.sid.len());
+                f(size);
+            })?;
+            unsafe { acl.0.add_allowed_ace(self.access_mask, self.sid) }?;
+            Ok(acl)
+        }
+    }
+}
+
+pub use acl_construction::{AddAllowAceAcl, EmptyAcl};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::TestSysErr;
+
+    #[test]
+    fn create_empty_acl() {
+        let acl_constructor = EmptyAcl::new();
+        let acl = acl_constructor
+            .create::<TestSysErr>()
+            .expect("could not create ACL");
+    }
+
+    #[test]
+    fn create_allow_ace_acl() {
+        use winapi::um::winnt::PROCESS_TERMINATE;
+
+        let user =
+            TokenUser::process_user::<TestSysErr>().expect("could not get process token user");
+        let sid = user.sid();
+
+        let acl_constructor = EmptyAcl::new();
+        let acl_constructor = AddAllowAceAcl::new(acl_constructor, PROCESS_TERMINATE, sid);
+        let acl = acl_constructor
+            .create::<TestSysErr>()
+            .expect("could not create ACL");
+    }
+}


### PR DESCRIPTION
* Introduces a safe API for managing custom DACLs on Windows
* Switches from `winapi` to `windows` crate for win32 bindings