### PR TITLE
Fix compile error on FreeBSD.

### DIFF
--- a/src/internals/prctl.rs
+++ b/src/internals/prctl.rs
@@ -59,9 +59,9 @@ pub fn set_process_nontraceable() -> anyhow::Result<()> {
 /// # Errors
 /// Returns an error when the underlying syscall returns an error.
 #[cfg(target_os = "freebsd")]
-pub fn is_tracer_present() -> anyhow::Result<Option<rustix::process::RawNonZeroPid>> {
+pub fn is_tracer_present() -> anyhow::Result<Option<rustix::process::Pid>> {
     match rustix::process::trace_status(None).map_anyhow()? {
-        rustix::process::TracingStatus::BeingTraced(pid) => Ok(Some(pid.as_raw_nonzero())),
+        rustix::process::TracingStatus::BeingTraced(pid) => Ok(Some(pid)),
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
This fixes a compile error on FreeBSD:

```
error[E0412]: cannot find type `RawNonZeroPid` in module `rustix::process`
  --> src/internals/prctl.rs:62:70
   |
62 | pub fn is_tracer_present() -> anyhow::Result<Option<rustix::process::RawNonZeroPid>> {
   |                                                                      ^^^^^^^^^^^^^ not found in `rustix::process`

For more information about this error, try `rustc --explain E0412`.
error: could not compile `secmem-proc` (lib) due to 1 previous error
```

It looks like `RawNonZeroPid` was [removed] in `rustix 0.38.0-alpha.1`.

[removed]: https://github.com/bytecodealliance/rustix/commit/eb68ba30d5472000da54cd024017f96bfab9df15